### PR TITLE
Add huxley options to gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@ var gulp = require( 'gulp' ),
     huxley = require( './index' );
 
 gulp.task( 'test', function() {
-  gulp.src('test')
+  gulp.src('test/**/Huxleyfile.json')
     .pipe( huxley( {
       root: __dirname
     } ) );

--- a/index.js
+++ b/index.js
@@ -2,37 +2,77 @@ var httpServer = require( 'http-server' ),
     remote = require( 'selenium-webdriver/remote' ),
     jar = require( 'selenium-server-standalone-jar' ),
     huxley = require( 'huxley' ),
-    through = require( 'through2' );
+    through = require( 'through2' ),
+    path = require( 'path' ),
+    gutil = require( 'gulp-util' );
 
 module.exports = function( options ) {
   options = options || {};
 
   var server,
       root = options.root || '../..',
-      port = options.port || 8000;
+      port = options.port || 8000,
+      browser = options.browser,
+      serverUrl = options.server,
+      driver = options.driver,
+      action = null,
+      paths = [],
+      selenium = null;
 
+  if (typeof driver === 'function') {
+    huxley.injectDriver(options.driver);
+  }
+
+  switch( options.action ) {
+    case 'record':
+      action = huxley.recordTasks;
+      break;
+    case 'update':
+      action = huxley.playbackTasksAndSaveScreenshots;
+      break;
+    default:
+      action = huxley.playbackTasksAndCompareScreenshots;
+  }
+
+  // Create HTTP server
   server = httpServer.createServer({
     root: root
   });
 
-  return through.obj( function( file, enc, callback ) {
-    server.listen( port, '', function() {
+  server.listen( port, '', function() {
       try {
-        var selenium = new remote.SeleniumServer( jar.path, {
+        // Create Selenium server
+        selenium = new remote.SeleniumServer( jar.path, {
           port: 4444
         } );
         selenium.start();
-        // Use defaults, code doesn't allow varargs unfortunately
-        huxley.playbackTasksAndCompareScreenshots( '', '', [ file.path ], function( err ) {
-          selenium.stop();
-          server.close();
-          callback( err );
-        });
-      } catch (e) {
+      } catch (err) {
         selenium.stop();
         server.close();
-        callback( e );
+        callback(err);
       }
     });
+
+  return through.obj( function( file, enc, callback ) {
+    paths.push( path.dirname( file.path ) );
+    this.push( file );
+    callback();
+  }, function(callback) {
+    try {
+      action( browser, serverUrl, paths, function( err ) {
+        if ( err ) {
+          gutil.log( err );
+        }
+        selenium.stop();
+        server.close();
+      });
+    } catch ( err ) {
+      this.emit('error', new gutil.PluginError('gulp-huxley', {
+        message: err
+      }));
+      selenium.stop();
+      server.close();
+    }
+    callback();
   } );
 };


### PR DESCRIPTION
I was working on porting [grunt-huxley](//github.com/chenglou/grunt-huxley) over the weekend and didn't see your project. I'm hoping we can merge our projects together? I'm glad to see that someone else was working on this as well :smile: 

This fork lets you to customize the huxley options directly from your `gulpfile.js`.

``` js
gulp.task( 'test', function() {
  gulp.src('test/**/Huxleyfile.json')
    .pipe( huxley( {
      root: __dirname,
      action: 'update',
      server: 'http://localhost:4444/wd/hub'
    } ) );
});
```

The gulp task also takes in the paths to the `Huxleyfile.json` files. It then grabs the directory names that those files are located in.
