### PR TITLE
Decouple http and selenium server from gulp-huxley

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,30 @@
 var gulp = require( 'gulp' ),
-    huxley = require( './index' );
+    gutil = require('gulp-util'),
+    huxley = require( './index' ),
+    SeleniumServer = require('selenium-webdriver/remote').SeleniumServer,
+    jar = require('selenium-server-standalone-jar'),
+    HttpServer = require('http-server');
 
-gulp.task( 'test', function() {
-  gulp.src('test/**/Huxleyfile.json')
+var selenium = null;
+
+gulp.task('http', function() {
+    HttpServer.createServer().listen(8000);
+});
+
+gulp.task('selenium', function() {
+    selenium = new SeleniumServer(jar.path, {
+        port: 4444
+    });
+    selenium.start();
+});
+
+gulp.task( 'test', ['selenium'], function() {
+  gulp.src('./test/**/Huxleyfile.json')
     .pipe( huxley( {
-      root: __dirname
+        action: 'record',
+        browser: 'chrome',
+        server: selenium.address()
     } ) );
 });
 
-gulp.task( 'default', [ 'test' ] );
+gulp.task( 'default', [ 'http', 'test' ] );

--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
-var httpServer = require( 'http-server' ),
-    remote = require( 'selenium-webdriver/remote' ),
-    jar = require( 'selenium-server-standalone-jar' ),
-    huxley = require( 'huxley' ),
+var huxley = require( 'huxley' ),
     through = require( 'through2' ),
     path = require( 'path' ),
     gutil = require( 'gulp-util' );
@@ -9,15 +6,11 @@ var httpServer = require( 'http-server' ),
 module.exports = function( options ) {
   options = options || {};
 
-  var server,
-      root = options.root || '../..',
-      port = options.port || 8000,
-      browser = options.browser,
+  var browser = options.browser,
       serverUrl = options.server,
       driver = options.driver,
       action = null,
-      paths = [],
-      selenium = null;
+      paths = [];
 
   if (typeof driver === 'function') {
     huxley.injectDriver(options.driver);
@@ -34,44 +27,21 @@ module.exports = function( options ) {
       action = huxley.playbackTasksAndCompareScreenshots;
   }
 
-  // Create HTTP server
-  server = httpServer.createServer({
-    root: root
-  });
-
-  server.listen( port, '', function() {
-      try {
-        // Create Selenium server
-        selenium = new remote.SeleniumServer( jar.path, {
-          port: 4444
-        } );
-        selenium.start();
-      } catch (err) {
-        selenium.stop();
-        server.close();
-        callback(err);
-      }
-    });
-
   return through.obj( function( file, enc, callback ) {
     paths.push( path.dirname( file.path ) );
     this.push( file );
     callback();
-  }, function(callback) {
+  }, function( callback ) {
     try {
       action( browser, serverUrl, paths, function( err ) {
         if ( err ) {
           gutil.log( err );
         }
-        selenium.stop();
-        server.close();
       });
     } catch ( err ) {
-      this.emit('error', new gutil.PluginError('gulp-huxley', {
+      this.emit( 'error', new gutil.PluginError('gulp-huxley', {
         message: err
       }));
-      selenium.stop();
-      server.close();
     }
     callback();
   } );


### PR DESCRIPTION
I think this will fix #1, with regards to either server not staying up long enough for the huxley tests to finish. Although `gulpfile.js` may become a little bit more verbose by shifting the responsibility of the servers to the user, it also adds for more flexibility.

I would imagine developers would _already_ have a working http server running that they want to run their tests on, so this shouldn't be a part of gulp-huxley.

Likewise, users may already have a selenium server installation or even a remote server they use for testing. This shouldn't be a part of gulp-huxley either.

Users can easily spin up a selenium server in `gulpfile.js` and list it as as a dependency for their huxley task. The selenium server should automatically shut down after the huxley task terminates, which resolves the issue with the server shutting down before huxley finishes.

In the end this allows the user the ability to customize everything while also making the gulp-huxley much simpler. _"Run huxley with these options"_.

I changed `gulpfile.js` to run both of the tasks by default. But the use case would be:

``` bash
$ gulp http # Create http server
```

``` bash
$ gulp test # Create selenium server and then start huxley.
```
