### PR TITLE
Update README.md to reflect the default action

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Options
 =======
 Option | Type   | Default | Description
 ------ | ----   | ------- | -----------
-action | string | 'compare' | 'default', 'record', 'update' or 'compare'
+action | string | 'default' | 'default', 'record', 'update' or 'compare'
 browserName | string | 'firefox' | 'firefox' (selenium) or 'chrome' (chromedriver)
 serverUrl | string | | see [Advanced Usage](https://github.com/chenglou/node-huxley/wiki/Advanced-usage) for a detailed Description
 injectedDriver | function | | see [Huxley API](https://github.com/chenglou/node-huxley/wiki/API) for a detailed Description  


### PR DESCRIPTION
While looking at the code I noticed that the "default" action is the default case rather than "compare".
